### PR TITLE
Patch to fix always opening Allow dialogue when authorizing due to Twitter authentication change.

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -5,7 +5,8 @@ module OmniAuth
   module Strategies
     class Twitter < OmniAuth::Strategies::OAuth
       option :name, 'twitter'
-      option :client_options, {:site => 'https://api.twitter.com'}
+      option :client_options, {:authorize_path => '/oauth/authenticate',
+                               :site => 'https://api.twitter.com'}
 
       uid { access_token.params[:user_id] }
 


### PR DESCRIPTION
Prevents authorising from opening Allow prompt on every authentication attempt. See: 

https://dev.twitter.com/docs/api/1/get/oauth/authenticate

Discussion of the issue is here (and links in it): http://stackoverflow.com/questions/8251519/rails-omniauth-twitter-asking-for-app-authorization-each-time-user-logs-in/8262479#8262479

I have noted you removed this as a default. There is a lot of discussion and issues around this w/r to issues with authorization vs. authentication at this point, the default behaviour is always asking to authorize, even when done.

Have since noted this: https://dev.twitter.com/discussions/3290

It may be that this is a bug on omniauth side and an update on the gem README may be a good idea stating to temporarily set configuration as :client_options => {:authorize_path => '/oauth/authentication'}. 

Thoughts?
