### PR TITLE
authenticate to authorize

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -5,7 +5,7 @@ module OmniAuth
   module Strategies
     class Twitter < OmniAuth::Strategies::OAuth
       option :name, 'twitter'
-      option :client_options, {:authorize_path => '/oauth/authenticate',
+      option :client_options, {:authorize_path => '/oauth/authorize',
                                :site => 'https://api.twitter.com'}
 
       uid { access_token.params[:user_id] }


### PR DESCRIPTION
Hello!

I changed the twitter.rb script replacing the /oauth/authenticate by /oauth/authorize because with "authenticate" I couldn't get permissions for sending direct messages. I searched a solution in forums and the only apparent solution was using "authorize" instead of "authenticate".
