### PR TITLE
Fixes OmniAuth module name in version.rb

### DIFF
--- a/lib/omniauth-twitter/version.rb
+++ b/lib/omniauth-twitter/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Twitter
     VERSION = "0.0.8"
   end


### PR DESCRIPTION
Module name should be OmniAuth, not Omniauth.
