### PR TITLE
Fix typo that caused x_auth_access_type setting to fail sometimes

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -50,7 +50,7 @@ module OmniAuth
           options[:authorize_params].merge!(:force_login => 'true', :screen_name => screen_name)
         end
         if x_auth_access_type
-          options[:request_params] || {}
+          options[:request_params] ||= {}
           options[:request_params].merge!(:x_auth_access_type => x_auth_access_type)
         end
 

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -18,4 +18,19 @@ describe OmniAuth::Strategies::Twitter do
       expect(subject.options.client_options.authorize_path).to eq('/oauth/authenticate')
     end
   end
+
+  describe 'request_phase' do
+    context 'no request params set and x_auth_access_type specified' do
+      before do
+        subject.options[:request_params] = nil
+        subject.stub(:session).and_return(
+          {'omniauth.params' => {'x_auth_access_type' => 'read'}})
+        subject.stub(:old_request_phase).and_return(:whatever)
+      end
+
+      it 'should not break' do
+        expect { subject.request_phase }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
A missing equals sign was breaking setting `x_auth_access_type` for me.
