### PR TITLE
Add default profile image flag

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -17,6 +17,7 @@ module OmniAuth
           :name => raw_info['name'],
           :location => raw_info['location'],
           :image => options[:secure_image_url] ? raw_info['profile_image_url_https'] : raw_info['profile_image_url'],
+          :default_image => raw_info['default_profile_image'],
           :description => raw_info['description'],
           :urls => {
             'Website' => raw_info['url'],


### PR DESCRIPTION
this flag indicates if the user has a custom or default avatar.  

see:
https://dev.twitter.com/docs/api/1.1/get/account/verify_credentials
