### PR TITLE
Update URL parameters to not return unused data

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -30,7 +30,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= MultiJson.load(access_token.get('/1.1/account/verify_credentials.json').body)
+        @raw_info ||= MultiJson.load(access_token.get('/1.1/account/verify_credentials.json?include_entities=false&skip_status=true').body)
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end


### PR DESCRIPTION
We don’t use the status or entities so there’s no reason to ask for that data to be sent over the wire.
