### PR TITLE
Add auth hash example to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,78 @@ The options are:
 
 * **use_authorize** - There are actually two URLs you can use against the Twitter API. As mentioned, the default is `https://api.twitter.com/oauth/authenticate`, but you also have `https://api.twitter.com/oauth/authorize`. Passing this option as `true` will use the second URL rather than the first. What's the difference? As described [here](https://dev.twitter.com/docs/api/1/get/oauth/authenticate), with `authenticate`, if your user has already granted permission to your application, Twitter will redirect straight back to your application, whereas `authorize` forces the user to go through the "grant permission" screen again. For certain use cases this may be necessary. *Example:* `http://yoursite.com/auth/twitter?use_authorize=true`. *Note:* You must have "Allow this application to be used to Sign in with Twitter" checked in [your application's settings](https://dev.twitter.com/apps) - without it your user will be asked to authorize your application each time they log in.
 
+## Authentication Hash
+An example auth hash available in `request.env['omniauth.auth']`:
+
+```ruby
+{
+  :provider => "twitter",
+  :uid => "123456",
+  :info => {
+    :nickname => "johnqpublic",
+    :name => "John Q Public",
+    :location => "Anytown, USA",
+    :image => "http://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png",
+    :description => "a very normal guy.",
+    :urls => {
+      :Website => nil,
+      :Twitter => "https://twitter.com/johnqpublic"
+    }
+  },
+  :credentials => {
+    :token => "a1b2c3d4...", # The OAuth 2.0 access token
+    :secret => "abcdef1234"
+  },
+  :extra => {
+    :access_token => "", # An OAuth::AccessToken object
+    :raw_info => {
+      :name => "John Q Public",
+      :listed_count" => 0,
+      :profile_sidebar_border_color" => "181A1E",
+      :url => nil,
+      :lang => "en",
+      :statuses_count => 129,
+      :profile_image_url => "http://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png",
+      :profile_background_image_url_https => "https://twimg0-a.akamaihd.net/profile_background_images/229171796/pattern_036.gif",
+      :location => "Anytown, USA",
+      :time_zone => "Chicago",
+      :follow_request_sent => false,
+      :id => 123456,
+      :profile_background_tile => true,
+      :profile_sidebar_fill_color => "666666",
+      :followers_count => 1,
+      :default_profile_image => false,
+      :screen_name => "",
+      :following => false,
+      :utc_offset => -3600,
+      :verified => false,
+      :favourites_count => 0,
+      :profile_background_color => "1A1B1F",
+      :is_translator => false,
+      :friends_count => 1,
+      :notifications => false,
+      :geo_enabled => true,
+      :profile_background_image_url => "http://twimg0-a.akamaihd.net/profile_background_images/229171796/pattern_036.gif",
+      :protected => false,
+      :description => "a very normal guy.",
+      :profile_link_color => "2FC2EF",
+      :created_at => "Thu Jul 4 00:00:00 +0000 2013",
+      :id_str => "123456",
+      :profile_image_url_https => "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png",
+      :default_profile => false,
+      :profile_use_background_image => false,
+      :entities => {
+        :description => {
+          :urls => []
+        }
+      },
+      :profile_text_color => "666666",
+      :contributors_enabled => false
+    }
+  }
+}
+```
+
 ## Watch the RailsCast
 
 Ryan Bates has put together an excellent RailsCast on OmniAuth:


### PR DESCRIPTION
It may be useful to have an example auth hash in the readme file.
