### PR TITLE
Add support for larger Twitter profile images

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -72,7 +72,7 @@ module OmniAuth
         when 'original'
           original_url.sub('_normal', '')
         when '400x400'
-          original_url.sub('400x400', '400x400')
+          original_url.sub('normal', '400x400')
         else
           original_url
         end

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -47,7 +47,7 @@ describe OmniAuth::Strategies::Twitter do
       it 'should return secure image with size specified' do
         @options = { :secure_image_url => 'true', :image_size => '400x400' }
         allow(subject).to receive(:raw_info).and_return(
-          { 'profile_image_url_https' => 'https://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0_400x400.png' }
+          { 'profile_image_url_https' => 'https://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0_normal.png' }
         )
         expect(subject.info[:image]).to eq('https://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0_400x400.png')
       end


### PR DESCRIPTION
Twitter has recently added support for 400x400 thumbnails coinciding with their re-design. This PR adds support for that.
