### PR TITLE
Fixed support for skip_info option to ensure raw_info isn't called

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -27,7 +27,7 @@ module OmniAuth
       end
 
       extra do
-        { :raw_info => raw_info }
+        skip_info? ? {} : { :raw_info => raw_info }
       end
 
       def raw_info

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -53,6 +53,16 @@ describe OmniAuth::Strategies::Twitter do
     end
   end
 
+  describe 'skip_info option' do
+    context 'when skip info option is enabled' do
+      it 'should not include raw_info in extras hash' do
+        @options = { :skip_info => true }
+        allow(subject).to receive(:raw_info).and_return({:foo => 'bar'})
+        expect(subject.extra[:raw_info]).to eq(nil)
+      end
+    end
+  end
+
   describe 'request_phase' do
     context 'with no request params set and x_auth_access_type specified' do
       before do


### PR DESCRIPTION
Currently, the skip_info option isn't working as expected. When skip_info is enabled, there should be no follow-on API call to Twitter to fetch the user's information. However, raw_info is being populated in auth_hash.extra regardless of the skip_info option. This patch fixes auth_hash.extra to only include raw_info when skip_info is false.
