### PR TITLE
Use new stub syntax (to remove deprecation warnings)

### DIFF
--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -80,10 +80,10 @@ describe OmniAuth::Strategies::Twitter do
     context "with no request params set and use_authorize options provided" do
       before do
         @options = { :use_authorize => true }
-        subject.stub(:request).and_return(
-          double('Request', {:params => {}})
-        )
-        subject.stub(:old_request_phase).and_return(:whatever)
+        allow(subject).to receive(:request) do
+          double('Request', {:params => {} })
+        end
+        allow(subject).to receive(:old_request_phase) { :whatever }
       end
 
       it "should switch authorize_path from authenticate to authorize" do


### PR DESCRIPTION
When I ran the tests (with rspec 2.99.0), it said:

```
.........

Deprecation Warnings:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/sean/dev/omniauth-twitter/spec/omniauth/strategies/twitter_spec.rb:83:in `block (4 levels) in <top (required)>'.
```

So I fixed them. 
