### PR TITLE
Replace multi_json with standard library json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,12 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
+
+gemspec
 
 gem 'rake'
-# Specify your gem's dependencies in omniauth-twitter.gemspec
-gemspec
+
+group :test do
+  gem 'rspec', '~> 3.2'
+  gem 'rack-test'
+  gem 'simplecov'
+  gem 'webmock'
+end

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -1,5 +1,5 @@
 require 'omniauth-oauth'
-require 'multi_json'
+require 'json'
 
 module OmniAuth
   module Strategies
@@ -31,7 +31,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= MultiJson.load(access_token.get('/1.1/account/verify_credentials.json?include_entities=false&skip_status=true').body)
+        @raw_info ||= JSON.load(access_token.get('/1.1/account/verify_credentials.json?include_entities=false&skip_status=true').body)
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end

--- a/omniauth-twitter.gemspec
+++ b/omniauth-twitter.gemspec
@@ -19,8 +19,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'json', '~> 1.3'
   s.add_dependency 'omniauth-oauth', '~> 1.1'
-  s.add_development_dependency 'rspec', '~> 2.7'
-  s.add_development_dependency 'rack-test'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'webmock'
+  s.add_development_dependency 'bundler', '~> 1.0'
 end

--- a/omniauth-twitter.gemspec
+++ b/omniauth-twitter.gemspec
@@ -8,19 +8,17 @@ Gem::Specification.new do |s|
   s.authors     = ["Arun Agrawal"]
   s.email       = ["arunagw@gmail.com"]
   s.homepage    = "https://github.com/arunagw/omniauth-twitter"
-  s.summary     = %q{OmniAuth strategy for Twitter}
   s.description = %q{OmniAuth strategy for Twitter}
+  s.summary     = s.description
   s.license     = "MIT"
-
-  s.rubyforge_project = "omniauth-twitter"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'multi_json', '~> 1.3'
-  s.add_runtime_dependency 'omniauth-oauth', '~> 1.0'
+  s.add_dependency 'json', '~> 1.3'
+  s.add_dependency 'omniauth-oauth', '~> 1.1'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
 $:.unshift File.expand_path('..', __FILE__)
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  minimum_coverage(94.59)
+end
 require 'rspec'
 require 'rack/test'
 require 'webmock/rspec'


### PR DESCRIPTION
MultiJson is no longer necessary now that the JSON gem has been moved into the Ruby standard library. It has been removed as a dependency in the latest version of `omniauth-oauth`, which I just released. Please merge and release this change.