### PR TITLE
add email in response closes #95

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -16,6 +16,7 @@ module OmniAuth
         {
           :nickname => raw_info['screen_name'],
           :name => raw_info['name'],
+          :email => raw_info["email"],
           :location => raw_info['location'],
           :image => image_url,
           :description => raw_info['description'],

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -32,7 +32,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= JSON.load(access_token.get('/1.1/account/verify_credentials.json?include_entities=false&skip_status=true').body)
+        @raw_info ||= JSON.load(access_token.get('/1.1/account/verify_credentials.json?include_entities=false&skip_status=true&include_email=true').body)
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -26,6 +26,37 @@ describe OmniAuth::Strategies::Twitter do
     end
   end
 
+  describe 'info' do
+    before do
+      allow(subject).to receive(:raw_info).and_return(raw_info_hash)
+    end
+
+    it 'should returns the nickname' do
+      expect(subject.info[:nickname]).to eq(raw_info_hash['screen_name'])
+    end
+
+    it 'should returns the name' do
+      expect(subject.info[:name]).to eq(raw_info_hash['name'])
+    end
+
+    it 'should returns the email' do
+      expect(subject.info[:email]).to eq(raw_info_hash['email'])
+    end
+
+    it 'should returns the location' do
+      expect(subject.info[:location]).to eq(raw_info_hash['location'])
+    end
+
+    it 'should returns the description' do
+      expect(subject.info[:description]).to eq(raw_info_hash['description'])
+    end
+
+    it 'should returns the urls' do
+      expect(subject.info[:urls]['Website']).to eq(raw_info_hash['url'])
+      expect(subject.info[:urls]['Twitter']).to eq("https://twitter.com/#{raw_info_hash['screen_name']}")
+    end
+  end
+
   describe 'image_size option' do
     context 'when user has an image' do
       it 'should return image with size specified' do
@@ -112,4 +143,17 @@ describe OmniAuth::Strategies::Twitter do
       end
     end
   end
+end
+
+private
+
+def raw_info_hash
+  {
+    'screen_name' => 'foo',
+    'name' => 'Foo Bar',
+    'email' => 'foo@example.com',
+    'location' => 'India',
+    'description' => 'Developer',
+    'url' => 'example.com/foobar'
+  }
 end


### PR DESCRIPTION
To get email address in response
- Added ```include_email``` parameter in ```verify_credentials``` request
- Added email keys in raw_info hash