### PR TITLE
Supported :image_size as Symbol in authentication options

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -65,7 +65,10 @@ module OmniAuth
 
       def image_url
         original_url = options[:secure_image_url] ? raw_info['profile_image_url_https'] : raw_info['profile_image_url']
-        case options[:image_size]
+        ## Allowing :image_size to specify as Symbol
+        # Converting :image_size to String if :image_size is non String
+        image_size = options[:image_size].is_a?(String) ? options[:image_size] : options[:image_size].to_s
+        case image_size
         when 'mini'
           original_url.sub('normal', 'mini')
         when 'bigger'

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -66,6 +66,14 @@ describe OmniAuth::Strategies::Twitter do
         )
         expect(subject.info[:image]).to eq('http://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0.png')
       end
+      
+      it 'should return image when size specified as Symbol' do
+        @options = { image_size: :original }
+        allow(subject).to receive(:raw_info).and_return(
+          { 'profile_image_url' => 'http://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0_normal.png' }
+        )
+        expect(subject.info[:image]).to eq('http://twimg0-a.akamaihd.net/sticky/default_profile_images/default_profile_0.png')
+      end
 
       it 'should return bigger image when bigger size specified' do
         @options = { :image_size => 'bigger' }


### PR DESCRIPTION
Allowed :image_size as Symbol in authentication options