### PR TITLE
Allow passing a callback_url param

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -61,8 +61,14 @@ module OmniAuth
         old_request_phase
       end
 
+      alias :old_callback_url :callback_url
+
       def callback_url
-        request.params['callback_url']
+        if request.params['callback_url']
+          request.params['callback_url']
+        else
+          old_callback_url
+        end
       end
 
       def callback_path

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -62,7 +62,17 @@ module OmniAuth
       end
 
       def callback_url
-        request.params['callback_url'] || super
+        request.params['callback_url']
+      end
+
+      def callback_path
+        params = session['omniauth.params']
+
+        if params.nil? || params['callback_url'].nil?
+          super
+        else
+          URI(params['callback_url']).path
+        end
       end
 
       private

--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -61,6 +61,10 @@ module OmniAuth
         old_request_phase
       end
 
+      def callback_url
+        request.params['callback_url'] || super
+      end
+
       private
 
       def image_url

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -130,6 +130,47 @@ describe OmniAuth::Strategies::Twitter do
       end
     end
 
+    context 'with a specified callback_url in the params' do
+      before do
+        params = { 'callback_url' => 'http://foo.dev/auth/twitter/foobar' }
+        allow(subject).to receive(:request) do
+          double('Request', :params => params)
+        end
+        allow(subject).to receive(:session) do
+          double('Session', :[] => { 'callback_url' => params['callback_url'] })
+        end
+        allow(subject).to receive(:old_request_phase) { :whatever }
+      end
+
+      it 'should use the callback_url' do
+        expect(subject.callback_url).to eq 'http://foo.dev/auth/twitter/foobar'
+      end
+
+      it 'should return the correct callback_path' do
+        expect(subject.callback_path).to eq '/auth/twitter/foobar'
+      end
+    end
+
+    context 'with no callback_url set' do
+      before do
+        allow(subject).to receive(:request) do
+          double('Request', :params => {})
+        end
+        allow(subject).to receive(:session) do
+          double('Session', :[] => {})
+        end
+        allow(subject).to receive(:old_request_phase) { :whatever }
+      end
+
+      it 'callback_url should return nil' do
+        expect(subject.callback_url).to be_nil
+      end
+
+      it 'should return the default callback_path value' do
+        expect(subject.callback_path).to eq '/auth/twitter/callback'
+      end
+    end
+
     context "with no request params set and force_login specified" do
       before do
         allow(subject).to receive(:request) do

--- a/spec/omniauth/strategies/twitter_spec.rb
+++ b/spec/omniauth/strategies/twitter_spec.rb
@@ -160,10 +160,11 @@ describe OmniAuth::Strategies::Twitter do
           double('Session', :[] => {})
         end
         allow(subject).to receive(:old_request_phase) { :whatever }
+        allow(subject).to receive(:old_callback_url).and_return(:old_callback)
       end
 
       it 'callback_url should return nil' do
-        expect(subject.callback_url).to be_nil
+        expect(subject.callback_url).to eq :old_callback
       end
 
       it 'should return the default callback_path value' do


### PR DESCRIPTION
When building an application we need to do two types of Twitter
authentication - one for signing in to our application (and creating a
`User`) and another for associating Twitter accounts to their `User`
account.

By passing a custom `callback_url` param we can have one controller
method for signing in and another one for the associating part and just
have the application set the callback when starting the authentication
process.
