### PR TITLE
Returns image_url method if original_url var is not present

### DIFF
--- a/lib/omniauth/strategies/twitter.rb
+++ b/lib/omniauth/strategies/twitter.rb
@@ -85,6 +85,8 @@ module OmniAuth
 
       def image_url
         original_url = options[:secure_image_url] ? raw_info['profile_image_url_https'] : raw_info['profile_image_url']
+        return unless original_url.present?
+        
         case options[:image_size]
         when 'mini'
           original_url.sub('normal', 'mini')


### PR DESCRIPTION
Was receiving an error that on calling sub for the original_url because it was nil, so just exiting the metho if it's nil