### PR TITLE
Add `ruby@4.0` to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'jruby']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0', 'jruby']
       fail-fast: false
       max-parallel: 10
     runs-on: ubuntu-latest

--- a/omniauth-twitter.gemspec
+++ b/omniauth-twitter.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 1.9.3')
   s.add_dependency 'omniauth-oauth', '~> 1.1'
   s.add_dependency 'rack'
+  s.add_dependency 'cgi'
 end


### PR DESCRIPTION
According to [Ruby 4.0's Release Notes][notes], the stdlib no longer includes the CGI library by default. This means that `CGI.parse` is no longer available without explicitly requiring the [cgi][] gem as a dependency.

To uncover this requirement, add `4.0` to the `ruby` matrix in the GitHub actions configuration file, then add `cgi` as a dependency to the gemspec.

Without explicit access, attempts to OAuth fail with an error message including:

```
undefined method 'parse' for class CGI: NoMethodError, undefined method 'parse' for class CGI
```

[cgi]: https://github.com/ruby/cgi
[notes]: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/#stdlib-compatibility-issues